### PR TITLE
Adding OWASP France meetup in events list

### DIFF
--- a/content/page/events.en.md
+++ b/content/page/events.en.md
@@ -15,6 +15,7 @@ Exodus Privacy is regulary performing talks about its works and results, in Fren
 * [FR] "Digital Culture" day at the library of the University of Nantes, Nantes (France), 20th June 2019
 * [FR] The French librarians association congress, Paris (France), 7th June 2019
 * [FR] [The Ubuntu Party of Paris](https://www.ubuntu-paris.org/), Paris (France), 19th May 2019
+* [FR] [OWASP France Meetup](https://www.meetup.com/fr-FR/owasp-france/events/259215813/), Paris (France), 4th April 2019
 * [FR] [Seminar "Privacy, mobile and security"](https://fdln.insa-rennes.fr/decrypter/seminaire-vie-privee-mobile-et-securite/), Rennes (France), February 2019
 * [EN] [FOSDEM "Decentralized Internet and Privacy" devroom](https://fosdem.org/2019/schedule/track/decentralized_internet_and_privacy/), Bruxelles (Belgium), February 2019 [(video)](https://peertube.tamanoir.foucry.net/videos/watch/596cadb2-6055-437a-bd86-3b0e98458ca1)
 

--- a/content/page/events.fr.md
+++ b/content/page/events.fr.md
@@ -15,6 +15,7 @@ L'association Exodus Privacy propose régulièrement des conférences et interve
 * [FR] Journée "Culture Numérique" à la bibliothèque universitaire de Nantes, Nantes (France), 20 juin 2019
 * [FR] Congrès de l'ABF (association des bibliothécaires de France), Paris (France), 7 juin 2019
 * [FR] [Ubuntu Party de Paris](https://www.ubuntu-paris.org/), Paris (France), 19 mai 2019
+* [FR] [Meetup OWASP France](https://www.meetup.com/fr-FR/owasp-france/events/259215813/), Paris, 4 avril 2019
 * [FR] [Séminaire "Vie privée, mobile et sécurité", dans le cadre du Festival des Libertés Numériques](https://fdln.insa-rennes.fr/decrypter/seminaire-vie-privee-mobile-et-securite/), Rennes, février 2019
 * [EN] [Devroom "Decentralized Internet and Privacy" du FOSDEM](https://fosdem.org/2019/schedule/track/decentralized_internet_and_privacy/), Bruxelles (Belgique), février 2019 [(video)](https://peertube.tamanoir.foucry.net/videos/watch/596cadb2-6055-437a-bd86-3b0e98458ca1)
 

--- a/content/page/events.fr.md
+++ b/content/page/events.fr.md
@@ -8,15 +8,15 @@ draft: false
 L'association Exodus Privacy propose régulièrement des conférences et interventions présentant son travail et ses résultats, en français ou en anglais. Si vous organisez un événement et souhaitez nous inviter, n'hésitez pas à [nous contacter](/fr/page/who/).
 
 ## Evénements à venir
-* [FR] [Entrée libre](https://www.centredesabeilles.fr/entree-libre/), Quimper (France), le mardi 27 août à 16h
+* [FR] [Entrée libre](https://www.centredesabeilles.fr/entree-libre/), Quimper, le mardi 27 août à 16h
 
 ## 2019
-* [FR] [Pas Sage en Seine](https://passageenseine.fr/), Choisy-Le-Roi (France), 28, 29 et 30 juin 2019
-* [FR] Journée "Culture Numérique" à la bibliothèque universitaire de Nantes, Nantes (France), 20 juin 2019
-* [FR] Congrès de l'ABF (association des bibliothécaires de France), Paris (France), 7 juin 2019
-* [FR] [Ubuntu Party de Paris](https://www.ubuntu-paris.org/), Paris (France), 19 mai 2019
+* [FR] [Pas Sage en Seine](https://passageenseine.fr/), Choisy-Le-Roi, 28, 29 et 30 juin 2019
+* [FR] Journée "Culture Numérique" à la bibliothèque universitaire de Nantes, Nantes, 20 juin 2019
+* [FR] Congrès de l'ABF (association des bibliothécaires de France), Paris, 7 juin 2019
+* [FR] [Ubuntu Party de Paris](https://www.ubuntu-paris.org/), Paris, 19 mai 2019
 * [FR] [Meetup OWASP France](https://www.meetup.com/fr-FR/owasp-france/events/259215813/), Paris, 4 avril 2019
-* [FR] [Séminaire "Vie privée, mobile et sécurité", dans le cadre du Festival des Libertés Numériques](https://fdln.insa-rennes.fr/decrypter/seminaire-vie-privee-mobile-et-securite/), Rennes, février 2019
+* [FR] [Séminaire "Vie privée, mobile et sécurité" - Festival des Libertés Numériques](https://fdln.insa-rennes.fr/decrypter/seminaire-vie-privee-mobile-et-securite/), Rennes, février 2019
 * [EN] [Devroom "Decentralized Internet and Privacy" du FOSDEM](https://fosdem.org/2019/schedule/track/decentralized_internet_and_privacy/), Bruxelles (Belgique), février 2019 [(video)](https://peertube.tamanoir.foucry.net/videos/watch/596cadb2-6055-437a-bd86-3b0e98458ca1)
 
 ## 2018


### PR DESCRIPTION
Alongside with https://github.com/Exodus-Privacy/anim-com/pull/11

- Added OWASP meetup
- Removed France next to city names in French page (as we started to do it that way)