### PR TITLE
Always underline links

### DIFF
--- a/themes/hugo-bootstrap/layouts/partials/head.html
+++ b/themes/hugo-bootstrap/layouts/partials/head.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="{{ "assets/css/all.min.css" | relURL }}" />
   <link rel="stylesheet" href="{{ "assets/css/style.css" | relURL }}">
   <link rel="stylesheet" href="{{ "assets/css/tomorrow-night.css" | relURL }}">
+  <link rel="stylesheet" href="{{ "assets/css/custom.css" | relURL }}">
 
   {{ partial "base/favicon" . }}
 </head>

--- a/themes/hugo-bootstrap/static/assets/css/custom.css
+++ b/themes/hugo-bootstrap/static/assets/css/custom.css
@@ -1,0 +1,4 @@
+
+div.post-container a:not(.btn) {
+  text-decoration: underline !important;
+}


### PR DESCRIPTION
Fixes #91 

I made it so it underlines links on every page except on buttons

**Example:**
![image](https://user-images.githubusercontent.com/6069449/85232253-e2b79000-b3fd-11ea-8581-471f28cb8164.png)
