### PR TITLE
Add a button on home page to access exodus

### DIFF
--- a/themes/hugo-bootstrap/i18n/en.toml
+++ b/themes/hugo-bootstrap/i18n/en.toml
@@ -4,6 +4,9 @@ other = "Analyzes privacy concerns in Android applications."
 [discover]
 other = "Discover what we do"
 
+[check]
+other = "Check an app"
+
 [recentPosts]
 other = "Recent posts"
 

--- a/themes/hugo-bootstrap/i18n/fr.toml
+++ b/themes/hugo-bootstrap/i18n/fr.toml
@@ -4,6 +4,9 @@ other = "Analyse les problèmes de vie privée dans les applications Android."
 [discover]
 other = "Découvrez ce que nous faisons"
 
+[check]
+other = "Vérifier une application"
+
 [recentPosts]
 other = "Derniers articles"
 

--- a/themes/hugo-bootstrap/layouts/index.html
+++ b/themes/hugo-bootstrap/layouts/index.html
@@ -21,13 +21,20 @@
   {{ partial "base/header" . }}
   <div class="container">
     <div class="row justify-content-md-center mt-4">
-      <div class="col-lg-6 col-md-10 text-center text-white">
+      <div class="col-lg-12 col-md-10 text-center text-white">
         <h1>Exodus Privacy</h1>
         <img src="/media/logo.png" alt="Exodus Privacy logo" width="300px" class="mt-4 mb-4" />
         <h3>{{ i18n "description" }}</h3>
-        <p class="mt-4">
-          <a class="btn bg-white btn-lg" href={{ "page/what/" | relLangURL }}>{{ i18n "discover" }}</a>
-        </p>
+      </div>
+      <div class="col-lg-6 col-md-10 mt-4 text-lg-right text-center">
+        <a class="btn bg-white btn-lg" style="min-width: 220px;" href={{ "page/what/" | relLangURL }}>
+          {{ i18n "discover" }}
+        </a>
+      </div>
+      <div class="col-lg-6 col-md-10 mt-4 text-lg-left text-center">
+        <a class="btn bg-white btn-lg" style="min-width: 220px;" href="https://reports.exodus-privacy.eu.org/">
+          {{ i18n "check" }}
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Add a `Check an app` button on our home page to lead to exodus directly (very popular request :smile:)

**Screenshots:**

On big screens:
![image](https://user-images.githubusercontent.com/6069449/87584166-5f781a00-c6dd-11ea-9651-bb17bfb8cde6.png)

On mobile:
![image](https://user-images.githubusercontent.com/6069449/87584248-7e76ac00-c6dd-11ea-8991-27c5e424f5f4.png)
