### PR TITLE
Fix language selector links to current URI instead of home page

### DIFF
--- a/themes/hugo-bootstrap/layouts/partials/base/header.html
+++ b/themes/hugo-bootstrap/layouts/partials/base/header.html
@@ -17,14 +17,14 @@
           </li>
       {{end}}
     </ul>
-    {{ if gt (len .Site.Home.AllTranslations) 1 }}
+    {{ if gt (len .AllTranslations) 1 }}
         <ul class="navbar-nav">
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle text-white" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <i class="fa fa-language"></i>
                 </a>
                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-                    {{ range .Site.Home.AllTranslations }}
+                    {{ range .AllTranslations }}
                         <a class="dropdown-item" href="{{ .Permalink }}">{{ .Language.LanguageName }}</a>
                     {{ end }}
                 </div>


### PR DESCRIPTION
## Goal

- Redirect to the current URI with selected language instead of home page when switching language with dropdown selector

## Informations

According to https://gohugo.io/content-management/multilingual/#reference-the-translated-content

Fix https://github.com/Exodus-Privacy/website/issues/40