### PR TITLE
feat: Add new privacy policy page

### DIFF
--- a/content/page/privacy-policy.en.md
+++ b/content/page/privacy-policy.en.md
@@ -1,0 +1,20 @@
+---
+title: "Privacy policy"
+date: 2022-02-08 12:39:00
+draft: false
+---
+
+## Privacy Policy (Android)
+
+The εxodus Android application does not collect any personal information.
+
+The application requires the following permissions:
+
+* *INTERNET*: This permission is required so that the application can query the reports on the main εxodus instance <https://reports.exodus-privacy.eu.org/>. It is not used for any other purpose.
+* *ACCESS_NETWORK_STATE*: This permission allows us to know whether you are connected to the Internet before making any request.
+
+The application transmits the list of installed applications on the device, mixed with a number of random applications (not present on the device) in order to anonymize the list. This list is not kept by the εxodus server.
+
+On the εxodus API we keep some information for 16 days, for abuse prevention: IP address, date, time, requested URL and user-agent.
+
+The application does not contain any tracker, you can check it on its report: <https://reports.exodus-privacy.eu.org/en/reports/org.eu.exodus_privacy.exodusprivacy/latest/>

--- a/content/page/privacy-policy.en.md
+++ b/content/page/privacy-policy.en.md
@@ -6,15 +6,15 @@ draft: false
 
 ## Privacy Policy (Android)
 
-The εxodus Android application does not collect any personal information.
+The Exodus Android application does not collect any personal information.
 
 The application requires the following permissions:
 
 * *INTERNET*: This permission is required so that the application can query the reports on the main εxodus instance <https://reports.exodus-privacy.eu.org/>. It is not used for any other purpose.
-* *ACCESS_NETWORK_STATE*: This permission allows us to know whether you are connected to the Internet before making any request.
+* *ACCESS_NETWORK_STATE*: This permission allows the application to know whether you are connected to the Internet before making any request.
 
 The application transmits the list of installed applications on the device, mixed with a number of random applications (not present on the device) in order to anonymize the list. This list is not kept by the εxodus server.
 
-On the εxodus API we keep some information for 16 days, for abuse prevention: IP address, date, time, requested URL and user-agent.
+On the εxodus API server, we keep some information for 16 days, for abuse prevention: IP address, date, time, requested URL and user-agent.
 
 The application does not contain any tracker, you can check it on its report: <https://reports.exodus-privacy.eu.org/en/reports/org.eu.exodus_privacy.exodusprivacy/latest/>


### PR DESCRIPTION
Add a new page for storing the Android app privacy policy for https://github.com/Exodus-Privacy/exodus-android-app/issues/111

The new page will be hosted at: https://exodus-privacy.eu.org/en/page/privacy-policy/

**Screenshot:**

![image](https://user-images.githubusercontent.com/6069449/153054402-18568d8b-e856-4676-866c-f6cf7d34048d.png)
