### PR TITLE
Add scientist category to press page (Issue #159)

### DIFF
--- a/content/page/press.en.md
+++ b/content/page/press.en.md
@@ -46,7 +46,9 @@ draft: false
 * **Gizmodo** - *Nov 28 2017* - [Study: Vast Majority of Google Play Apps Are Covertly Tracking Users](https://gizmodo.com/study-vast-majority-of-google-play-apps-are-covertly-t-1820821682)
 * **BoingBoing** - *Nov 25 2017* - [Researchers craft Android app that reveals to find horrific menagerie](https://boingboing.net/2017/11/25/la-la-la-cant-hear-you.html)
 * **The Intercept** - *Nov 24 2017* - [Staggering Variety of Clandestine Trackers Found in Popular](https://theintercept.com/2017/11/24/staggering-variety-of-clandestine-trackers-found-in-popular-android-apps/)
+## Scientist publications in English
 
+* **INRIA** — *Apr 25 2022* — [The price to play](https://dl.acm.org/doi/abs/10.1145/3485447.3512279)
 ## French press
 
 ### 2021
@@ -100,3 +102,6 @@ draft: false
 * **LCI** - *Nov 29 2017* - [Ce qu'il faut savoir sur les trackers présents dans nos applications mobiles](https://www.lci.fr/high-tech/une-invasion-de-trackers-dans-nos-applications-le-bon-coin-allo-cine-mobiles-android-iphone-2071872.html)
 * **Next Inpact** - *Nov 25 2017* - [Rencontre avec Exodus Privacy, qui révèle les trackers](https://www.nextinpact.com/news/105655-rencontre-avec-exodus-privacy-qui-revele-trackers-applications-android.htm)
 * **Le Monde** - *Nov 24 2017* - [Des mouchards cachés dans vos applications pour smartphones](http://www.lemonde.fr/pixels/article/2017/11/24/des-mouchards-caches-dans-vos-applications-pour-smartphones_5219892_4408996.html)
+## Scientist publications in French
+
+* **INRIA** — *Apr 25 2022* — [Jeux vidéo sur mobile : protéger la vie pvivée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)

--- a/content/page/press.en.md
+++ b/content/page/press.en.md
@@ -102,7 +102,6 @@ draft: false
 * **Numerama** - *Dec 8 2017* - [Lutter contre les mouchards des apps, une cause citoyenne](https://www.numerama.com/politique/313309-lutter-contre-les-mouchards-des-apps-une-cause-citoyenne-voici-lhistoire-dexodus-privacy.html)
 * **Tom's Guide** - *Dec 5 2017* - [Trois quarts des apps Android espionnent les utilisateurs](https://www.tomsguide.fr/actualite/applications-android-espionnage-utilisateurs,60333.html)
 * **LCI** - *Nov 29 2017* - [Ce qu'il faut savoir sur les trackers présents dans nos applications mobiles](https://www.lci.fr/high-tech/une-invasion-de-trackers-dans-nos-applications-le-bon-coin-allo-cine-mobiles-android-iphone-2071872.html)
-
 * **Next Inpact** - *Nov 25 2017* - [Rencontre avec Exodus Privacy, qui révèle les trackers](https://www.nextinpact.com/news/105655-rencontre-avec-exodus-privacy-qui-revele-trackers-applications-android.htm)
 
 * **Le Monde** - *Nov 24 2017* - [Des mouchards cachés dans vos applications pour smartphones](http://www.lemonde.fr/pixels/article/2017/11/24/des-mouchards-caches-dans-vos-applications-pour-smartphones_5219892_4408996.html)

--- a/content/page/press.en.md
+++ b/content/page/press.en.md
@@ -109,4 +109,4 @@ draft: false
 
 ## Scientifict publications in French
 
-* **INRIA** — *Apr 25 2022* — [Jeux vidéo sur mobile : protéger la vie pvivée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)
+* **INRIA** - *Apr 25 2022* - [Jeux vidéo sur mobile : protéger la vie pvivée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)

--- a/content/page/press.en.md
+++ b/content/page/press.en.md
@@ -103,7 +103,6 @@ draft: false
 * **Tom's Guide** - *Dec 5 2017* - [Trois quarts des apps Android espionnent les utilisateurs](https://www.tomsguide.fr/actualite/applications-android-espionnage-utilisateurs,60333.html)
 * **LCI** - *Nov 29 2017* - [Ce qu'il faut savoir sur les trackers présents dans nos applications mobiles](https://www.lci.fr/high-tech/une-invasion-de-trackers-dans-nos-applications-le-bon-coin-allo-cine-mobiles-android-iphone-2071872.html)
 * **Next Inpact** - *Nov 25 2017* - [Rencontre avec Exodus Privacy, qui révèle les trackers](https://www.nextinpact.com/news/105655-rencontre-avec-exodus-privacy-qui-revele-trackers-applications-android.htm)
-
 * **Le Monde** - *Nov 24 2017* - [Des mouchards cachés dans vos applications pour smartphones](http://www.lemonde.fr/pixels/article/2017/11/24/des-mouchards-caches-dans-vos-applications-pour-smartphones_5219892_4408996.html)
 
 ## Scientifict publications in French

--- a/content/page/press.en.md
+++ b/content/page/press.en.md
@@ -46,9 +46,11 @@ draft: false
 * **Gizmodo** - *Nov 28 2017* - [Study: Vast Majority of Google Play Apps Are Covertly Tracking Users](https://gizmodo.com/study-vast-majority-of-google-play-apps-are-covertly-t-1820821682)
 * **BoingBoing** - *Nov 25 2017* - [Researchers craft Android app that reveals to find horrific menagerie](https://boingboing.net/2017/11/25/la-la-la-cant-hear-you.html)
 * **The Intercept** - *Nov 24 2017* - [Staggering Variety of Clandestine Trackers Found in Popular](https://theintercept.com/2017/11/24/staggering-variety-of-clandestine-trackers-found-in-popular-android-apps/)
-## Scientist publications in English
+
+## Scientifict publications in English
 
 * **INRIA** — *Apr 25 2022* — [The price to play](https://dl.acm.org/doi/abs/10.1145/3485447.3512279)
+
 ## French press
 
 ### 2021
@@ -100,8 +102,11 @@ draft: false
 * **Numerama** - *Dec 8 2017* - [Lutter contre les mouchards des apps, une cause citoyenne](https://www.numerama.com/politique/313309-lutter-contre-les-mouchards-des-apps-une-cause-citoyenne-voici-lhistoire-dexodus-privacy.html)
 * **Tom's Guide** - *Dec 5 2017* - [Trois quarts des apps Android espionnent les utilisateurs](https://www.tomsguide.fr/actualite/applications-android-espionnage-utilisateurs,60333.html)
 * **LCI** - *Nov 29 2017* - [Ce qu'il faut savoir sur les trackers présents dans nos applications mobiles](https://www.lci.fr/high-tech/une-invasion-de-trackers-dans-nos-applications-le-bon-coin-allo-cine-mobiles-android-iphone-2071872.html)
+
 * **Next Inpact** - *Nov 25 2017* - [Rencontre avec Exodus Privacy, qui révèle les trackers](https://www.nextinpact.com/news/105655-rencontre-avec-exodus-privacy-qui-revele-trackers-applications-android.htm)
+
 * **Le Monde** - *Nov 24 2017* - [Des mouchards cachés dans vos applications pour smartphones](http://www.lemonde.fr/pixels/article/2017/11/24/des-mouchards-caches-dans-vos-applications-pour-smartphones_5219892_4408996.html)
-## Scientist publications in French
+ 
+## Scientifict publications in French
 
 * **INRIA** — *Apr 25 2022* — [Jeux vidéo sur mobile : protéger la vie pvivée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)

--- a/content/page/press.en.md
+++ b/content/page/press.en.md
@@ -49,7 +49,7 @@ draft: false
 
 ## Scientifict publications in English
 
-* **INRIA** — *Apr 25 2022* — [The price to play](https://dl.acm.org/doi/abs/10.1145/3485447.3512279)
+* **INRIA** - *Apr 25 2022* - [The price to play](https://dl.acm.org/doi/abs/10.1145/3485447.3512279)
 
 ## French press
 

--- a/content/page/press.en.md
+++ b/content/page/press.en.md
@@ -106,7 +106,7 @@ draft: false
 * **Next Inpact** - *Nov 25 2017* - [Rencontre avec Exodus Privacy, qui révèle les trackers](https://www.nextinpact.com/news/105655-rencontre-avec-exodus-privacy-qui-revele-trackers-applications-android.htm)
 
 * **Le Monde** - *Nov 24 2017* - [Des mouchards cachés dans vos applications pour smartphones](http://www.lemonde.fr/pixels/article/2017/11/24/des-mouchards-caches-dans-vos-applications-pour-smartphones_5219892_4408996.html)
- 
+
 ## Scientifict publications in French
 
 * **INRIA** — *Apr 25 2022* — [Jeux vidéo sur mobile : protéger la vie pvivée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)

--- a/content/page/press.fr.md
+++ b/content/page/press.fr.md
@@ -112,4 +112,4 @@ draft: false
 
 ## Parutions scientifiques anglophones
 
-* **INRIA** – *25 apr 2022* – [The price to play](https://dl.acm.org/doi/abs/10.1145/3485447.3512279)
+* **INRIA** - *25 Avr 2022* - [The price to play](https://dl.acm.org/doi/abs/10.1145/3485447.3512279)

--- a/content/page/press.fr.md
+++ b/content/page/press.fr.md
@@ -62,6 +62,7 @@ draft: false
 * **LCI** - *29 Nov 2017* - [Ce qu'il faut savoir sur les trackers présents dans nos applications mobiles](https://www.lci.fr/high-tech/une-invasion-de-trackers-dans-nos-applications-le-bon-coin-allo-cine-mobiles-android-iphone-2071872.html)
 * **Next Inpact** - *25 Nov 2017* - [Rencontre avec Exodus Privacy, qui révèle les trackers](https://www.nextinpact.com/news/105655-rencontre-avec-exodus-privacy-qui-revele-trackers-applications-android.htm)
 * **Le Monde** - *24 Nov 2017* - [Des mouchards cachés dans vos applications pour smartphones](http://www.lemonde.fr/pixels/article/2017/11/24/des-mouchards-caches-dans-vos-applications-pour-smartphones_5219892_4408996.html)
+
 ## Parutions Scientifiques Francophone
 
 * **INRIA** — *25 avr 2022* — [Jeux vidéo sur mobile : protéger la vie privée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)
@@ -108,6 +109,7 @@ draft: false
 * **Gizmodo** - *28 Nov 2017* - [Study: Vast Majority of Google Play Apps Are Covertly Tracking Users](https://gizmodo.com/study-vast-majority-of-google-play-apps-are-covertly-t-1820821682)
 * **BoingBoing** - *25 Nov 2017* - [Researchers craft Android app that reveals to find horrific menagerie](https://boingboing.net/2017/11/25/la-la-la-cant-hear-you.html)
 * **The Intercept** - *24 Nov 2017* - [Staggering Variety of Clandestine Trackers Found in Popular](https://theintercept.com/2017/11/24/staggering-variety-of-clandestine-trackers-found-in-popular-android-apps/)
+
 ## Parutions Scientifiques anglophone
 
 * **INRIA** – *25 apr 2022* – [The price to play](https://dl.acm.org/doi/abs/10.1145/3485447.3512279)

--- a/content/page/press.fr.md
+++ b/content/page/press.fr.md
@@ -63,7 +63,7 @@ draft: false
 * **Next Inpact** - *25 Nov 2017* - [Rencontre avec Exodus Privacy, qui révèle les trackers](https://www.nextinpact.com/news/105655-rencontre-avec-exodus-privacy-qui-revele-trackers-applications-android.htm)
 * **Le Monde** - *24 Nov 2017* - [Des mouchards cachés dans vos applications pour smartphones](http://www.lemonde.fr/pixels/article/2017/11/24/des-mouchards-caches-dans-vos-applications-pour-smartphones_5219892_4408996.html)
 
-## Parutions Scientifiques Francophone
+## Parutions scientifiques francophones
 
 * **INRIA** — *25 avr 2022* — [Jeux vidéo sur mobile : protéger la vie privée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)
 

--- a/content/page/press.fr.md
+++ b/content/page/press.fr.md
@@ -65,7 +65,7 @@ draft: false
 
 ## Parutions scientifiques francophones
 
-* **INRIA** — *25 avr 2022* — [Jeux vidéo sur mobile : protéger la vie privée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)
+* **INRIA** - *25 Avr 2022* - [Jeux vidéo sur mobile : protéger la vie privée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)
 
 ## Presse anglophone
 

--- a/content/page/press.fr.md
+++ b/content/page/press.fr.md
@@ -110,6 +110,6 @@ draft: false
 * **BoingBoing** - *25 Nov 2017* - [Researchers craft Android app that reveals to find horrific menagerie](https://boingboing.net/2017/11/25/la-la-la-cant-hear-you.html)
 * **The Intercept** - *24 Nov 2017* - [Staggering Variety of Clandestine Trackers Found in Popular](https://theintercept.com/2017/11/24/staggering-variety-of-clandestine-trackers-found-in-popular-android-apps/)
 
-## Parutions Scientifiques anglophone
+## Parutions scientifiques anglophones
 
 * **INRIA** – *25 apr 2022* – [The price to play](https://dl.acm.org/doi/abs/10.1145/3485447.3512279)

--- a/content/page/press.fr.md
+++ b/content/page/press.fr.md
@@ -62,6 +62,9 @@ draft: false
 * **LCI** - *29 Nov 2017* - [Ce qu'il faut savoir sur les trackers présents dans nos applications mobiles](https://www.lci.fr/high-tech/une-invasion-de-trackers-dans-nos-applications-le-bon-coin-allo-cine-mobiles-android-iphone-2071872.html)
 * **Next Inpact** - *25 Nov 2017* - [Rencontre avec Exodus Privacy, qui révèle les trackers](https://www.nextinpact.com/news/105655-rencontre-avec-exodus-privacy-qui-revele-trackers-applications-android.htm)
 * **Le Monde** - *24 Nov 2017* - [Des mouchards cachés dans vos applications pour smartphones](http://www.lemonde.fr/pixels/article/2017/11/24/des-mouchards-caches-dans-vos-applications-pour-smartphones_5219892_4408996.html)
+## Parutions Scientifiques Francophone
+
+* **INRIA** — *25 avr 2022* — [Jeux vidéo sur mobile : protéger la vie privée en ligne](https://www.inria.fr/fr/jeux-video-smartphones-securite-donnees-personnelles-internet)
 
 ## Presse anglophone
 
@@ -105,3 +108,6 @@ draft: false
 * **Gizmodo** - *28 Nov 2017* - [Study: Vast Majority of Google Play Apps Are Covertly Tracking Users](https://gizmodo.com/study-vast-majority-of-google-play-apps-are-covertly-t-1820821682)
 * **BoingBoing** - *25 Nov 2017* - [Researchers craft Android app that reveals to find horrific menagerie](https://boingboing.net/2017/11/25/la-la-la-cant-hear-you.html)
 * **The Intercept** - *24 Nov 2017* - [Staggering Variety of Clandestine Trackers Found in Popular](https://theintercept.com/2017/11/24/staggering-variety-of-clandestine-trackers-found-in-popular-android-apps/)
+## Parutions Scientifiques anglophone
+
+* **INRIA** – *25 apr 2022* – [The price to play](https://dl.acm.org/doi/abs/10.1145/3485447.3512279)


### PR DESCRIPTION
Add ## Scientist publications in French; Scientist publication in English; Publications scientifique francophone ; Publications scientifique anglophone in pages `press.fr.md` and `press.en.md`, with *INRIA* publication about video games on smartphone.