### PR TITLE
Added new permission for next Exodus app release

### DIFF
--- a/content/page/privacy-policy.en.md
+++ b/content/page/privacy-policy.en.md
@@ -14,6 +14,7 @@ The application requires the following permissions:
 * *FOREGROUND_SERVICE*: This permission allows the application to execute a foreground service to get list of trackers and list of reports.
 * *INTERNET*: This permission is required so that the application can query the reports on the main εxodus instance <https://reports.exodus-privacy.eu.org/>. It is not used for any other purpose.
 * *QUERY_ALL_PACKAGES*: This permission allows the application to see all installed applications on your device.
+* *POST_NOTIFICATIONS*: This permission allows the application to post notifications. **This permission is only used on Android 13.**
 
 The application transmits the list of installed applications on the device, mixed with a number of random applications (not present on the device) in order to anonymize the list. This list is not kept by the εxodus server.
 

--- a/content/page/privacy-policy.en.md
+++ b/content/page/privacy-policy.en.md
@@ -10,9 +10,10 @@ The Exodus Android application does not collect any personal information.
 
 The application requires the following permissions:
 
-* *QUERY_ALL_PACKAGES*: This permission allows the application to see all installed applications on your device.
-* *INTERNET*: This permission is required so that the application can query the reports on the main εxodus instance <https://reports.exodus-privacy.eu.org/>. It is not used for any other purpose.
 * *ACCESS_NETWORK_STATE*: This permission allows the application to know whether you are connected to the Internet before making any request.
+* *FOREGROUND_SERVICE*: This permission allows the application to execute a foreground service to get list of trackers and list of reports.
+* *INTERNET*: This permission is required so that the application can query the reports on the main εxodus instance <https://reports.exodus-privacy.eu.org/>. It is not used for any other purpose.
+* *QUERY_ALL_PACKAGES*: This permission allows the application to see all installed applications on your device.
 
 The application transmits the list of installed applications on the device, mixed with a number of random applications (not present on the device) in order to anonymize the list. This list is not kept by the εxodus server.
 


### PR DESCRIPTION
- Added new permission [FOREGROUND_SERVICE](https://github.com/Exodus-Privacy/exodus-android-app/blob/9a02ded30df2670d62cb5c44418675e09b6c6580/app/src/main/AndroidManifest.xml#L8) in privacy policy to prepare next release.
- Sort permissions by alphabetical order

Please merge this commit at the end of the august month.