### PR TITLE
Update privacy policy for next update

### DIFF
--- a/content/page/privacy-policy.en.md
+++ b/content/page/privacy-policy.en.md
@@ -11,7 +11,7 @@ The Exodus Android application does not collect any personal information.
 The application requires the following permissions:
 
 * *ACCESS_NETWORK_STATE*: This permission allows the application to know whether you are connected to the Internet before making any request.
-* *FOREGROUND_SERVICE*: This permission allows the application to execute a foreground service to get list of trackers and list of reports.
+* *REORDER_TASKS*: This permission allows the application to reorder tasks executed during reports and trackers refresh.
 * *INTERNET*: This permission is required so that the application can query the reports on the main εxodus instance <https://reports.exodus-privacy.eu.org/>. It is not used for any other purpose.
 * *QUERY_ALL_PACKAGES*: This permission allows the application to see all installed applications on your device.
 * *POST_NOTIFICATIONS*: This permission allows the application to post notifications. **This permission is only used on Android 13.**


### PR DESCRIPTION
Next update of app is planned in may and one permission has changed
We have removed FOREGROUND_SERVICE permission because some devices doesn't accept to execute foreground service and generate crash (Some devices are too aggressive with apps and kill service because we don't ask to users to ignore battery optimizations)
https://github.com/Exodus-Privacy/exodus-android-app/issues/244

We have added REORDER_TASKS permission because we use the dispatcher to separate tasks in different threads to improve performance because before tasks were executed in the main thread generate a timeout (especially on devices with a lot of apps installed)
https://github.com/Exodus-Privacy/exodus-android-app/issues/238
https://github.com/Exodus-Privacy/exodus-android-app/issues/260
https://github.com/Exodus-Privacy/exodus-android-app/issues/264