### PR TITLE
Fix warning in Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Lint changelog file
       uses: docker://avtodev/markdown-lint:v1.5


### PR DESCRIPTION
Last PR for tonight :)
We have a warning in Github actions because checkout v3 use older version of node js