### PR TITLE
[FAQ] Add /e/OS App Lounge block and developer name and certificate presence informations

### DIFF
--- a/content/page/faq.en.md
+++ b/content/page/faq.en.md
@@ -15,6 +15,7 @@ draft: false
 * [How can I help you?](#help)
 * [Does the Exodus Privacy Android application embed trackers?](#exodus)
 * [Why do you have a YouTube channel when this platform belongs to Google?](#youtube)
+* [I have an /e/OS smartphone and my App Lounge app can't retrieve εxodus reports, why?](#eos)
 
 ---
 
@@ -81,6 +82,18 @@ Of course not, you can see [its own analysis report](https://reports.exodus-priv
 The goal of Exodus Privacy is to reach as many people as possible, the least tech-savvy and the most inclined to ignore what's happening in their smartphone. To reach this audience, it is necessary to go to it, because it will not come to us. So we have a YouTube channel and a Facebook page.
 
 You can find the links of our different media on [this page](/en/page/what/#videos).
+
+---
+
+**I have an /e/OS smartphone and my App Lounge app can't retrieve εxodus reports, why?  <a class="anchor" name="eos"></a>**
+
+Maybe we blocked your App Lounge client.
+
+For a few years now, /e/OS servers have been making requests to our API with a key we provided them. However, in October 2024, as /e/'s requests became too large for our servers (and our request to implement a better cache on their side failed), we informed them that this would no longer be possible and gave them several months to migrate (such as selfhosting an instance of εxodus on their premises). Indeed, despite their funding offer, we do not have the human resources or the desire to be a service provider for companies.
+
+Despite this, it was the /e/OS "App Lounge" app store that started making requests to our API, directly from /e/OS smartphones, causing a DDoS of our infrastructure.
+
+On March 6, 2025, we decided to block requests from /e/OS "App Lounge" clients to relieve our servers. Only App Lounge clients are blocked, your address is not banned, and you can still visit the εxodus platform.
 
 <style>
 a.anchor {

--- a/content/page/faq.en.md
+++ b/content/page/faq.en.md
@@ -16,6 +16,7 @@ draft: false
 * [Does the Exodus Privacy Android application embed trackers?](#exodus)
 * [Why do you have a YouTube channel when this platform belongs to Google?](#youtube)
 * [I have an /e/OS smartphone and my App Lounge app can't retrieve εxodus reports, why?](#eos)
+* [I'm developing an Android app, why is my name on εxodus?](#gdpr)
 
 ---
 
@@ -94,6 +95,18 @@ For a few years now, /e/OS servers have been making requests to our API with a k
 Despite this, it was the /e/OS "App Lounge" app store that started making requests to our API, directly from /e/OS smartphones, causing a DDoS of our infrastructure.
 
 On March 6, 2025, we decided to block requests from /e/OS "App Lounge" clients to relieve our servers. Only App Lounge clients are blocked, your address is not banned, and you can still visit the εxodus platform.
+
+---
+
+**I'm developing an Android app, why is my name on εxodus?  <a class="anchor" name="gdpr"></a>**
+
+εxodus analyzes Android apps from the Google Play Store and F-Droid.
+
+If you have provided your name as the developer of the app, it will be publicly displayed on the app page of the aforementioned stores. Also note that if you sign your app with a certificate, the name you provided there will also be publicly displayed.
+
+All this informations are used by εxodus to verify the origin of the applications and are therefore displayed on the pages of each report.
+
+You can, of course, send us a request by email to correct or delete your name. Please note, however, that if you have not changed your name in the aforementioned locations, it will be displayed again during future analyses of your application.
 
 <style>
 a.anchor {

--- a/content/page/faq.en.md
+++ b/content/page/faq.en.md
@@ -104,7 +104,7 @@ On March 6, 2025, we decided to block requests from /e/OS "App Lounge" clients t
 
 If you have provided your name as the developer of the app, it will be publicly displayed on the app page of the aforementioned stores. Also note that if you sign your app with a certificate, the name you provided there will also be publicly displayed.
 
-All this informations are used by εxodus to verify the origin of the applications and are therefore displayed on the pages of each report.
+All these information are used by εxodus to verify the origin of the applications and are therefore displayed on the pages of each report.
 
 You can, of course, send us a request by email to correct or delete your name. Please note, however, that if you have not changed your name in the aforementioned locations, it will be displayed again during future analyses of your application.
 

--- a/content/page/faq.fr.md
+++ b/content/page/faq.fr.md
@@ -16,6 +16,7 @@ draft: false
 * [L'application Android Exodus Privacy embarque-t'elle des pisteurs ?](#exodus)
 * [Pourquoi avez-vous une chaîne YouTube alors que cette plateforme appartient à Google ?](#youtube)
 * [J'ai un smartphone avec /e/OS et mon application App Lounge n'arrive plus à accéder aux rapports d'εxodus, pourquoi ?](#eos)
+* [Je développe une application Android, pourquoi mon nom figure t-il sur εxodus ?](#gdpr)
 
 ---
 
@@ -94,6 +95,18 @@ Depuis quelques années des serveurs de /e/OS faisaient des requêtes sur notre 
 Malgré cela, c'est le magasin d'applications "App Lounge" de /e/OS qui s'est mis à faire des requêtes vers notre API, directement depuis les smartphones /e/OS, engendrant un DDoS de notre infrastructure.
 
 Le 6 mars 2025 nous avons donc pris la décision de bloquer les requêtes des clients "App Lounge" de /e/OS afin de soulager nos serveurs. Seuls les clients App Lounge sont bloqués, votre adresse n'est pas bannie et vous pouvez toujours consulter la plateforme εxodus.
+
+---
+
+**Je développe une application Android, pourquoi mon nom figure t-il sur εxodus ?  <a class="anchor" name="gdpr"></a>**
+
+εxodus analyse les applications Android en provenance du Google Play Store et de F-Droid.
+
+Si vous avez indiqué votre nom en tant que personne ayant développé l'application, celui-ci apparaît publiquement sur la page de l'application des magasins précédemment mentionnés. Notez également que si vous signez votre application avec un certificat, le nom que vous y avez renseigné est également publique.
+
+Toutes ces informations sont utilisées par εxodus pour vérifier la provenance des applications et sont donc affichés sur les pages de chaque rapport.
+
+Vous pouvez bien sûr nous envoyer une demande de rectification ou suppression de votre nom par mail. Sachez cependant que si vous n'avez pas changé ce nom aux endroits précédement mentionnés, celui-ci sera de nouveau affiché lors de futures analyses de votre application.
 
 <style>
 a.anchor {

--- a/content/page/faq.fr.md
+++ b/content/page/faq.fr.md
@@ -104,7 +104,7 @@ Le 6 mars 2025 nous avons donc pris la décision de bloquer les requêtes des cl
 
 Si vous avez indiqué votre nom en tant que personne ayant développé l'application, celui-ci apparaît publiquement sur la page de l'application des magasins précédemment mentionnés. Notez également que si vous signez votre application avec un certificat, le nom que vous y avez renseigné est également publique.
 
-Toutes ces informations sont utilisées par εxodus pour vérifier la provenance des applications et sont donc affichés sur les pages de chaque rapport.
+Toutes ces informations sont utilisées par εxodus pour vérifier la provenance des applications et sont donc affichées sur les pages de chaque rapport.
 
 Vous pouvez bien sûr nous envoyer une demande de rectification ou suppression de votre nom par mail. Sachez cependant que si vous n'avez pas changé ce nom aux endroits précédement mentionnés, celui-ci sera de nouveau affiché lors de futures analyses de votre application.
 

--- a/content/page/faq.fr.md
+++ b/content/page/faq.fr.md
@@ -102,7 +102,7 @@ Le 6 mars 2025 nous avons donc pris la décision de bloquer les requêtes des cl
 
 εxodus analyse les applications Android en provenance du Google Play Store et de F-Droid.
 
-Si vous avez indiqué votre nom en tant que personne ayant développé l'application, celui-ci apparaît publiquement sur la page de l'application des magasins précédemment mentionnés. Notez également que si vous signez votre application avec un certificat, le nom que vous y avez renseigné est également publique.
+Si vous avez indiqué votre nom en tant que personne ayant développé l'application, celui-ci apparaît publiquement sur la page de l'application des magasins précédemment mentionnés. Notez également que si vous signez votre application avec un certificat, le nom que vous y avez renseigné est également public.
 
 Toutes ces informations sont utilisées par εxodus pour vérifier la provenance des applications et sont donc affichées sur les pages de chaque rapport.
 

--- a/content/page/faq.fr.md
+++ b/content/page/faq.fr.md
@@ -15,6 +15,7 @@ draft: false
 * [Comment faire si l'on souhaite vous aider ?](#aider)
 * [L'application Android Exodus Privacy embarque-t'elle des pisteurs ?](#exodus)
 * [Pourquoi avez-vous une chaîne YouTube alors que cette plateforme appartient à Google ?](#youtube)
+* [J'ai un smartphone avec /e/OS et mon application App Lounge n'arrive plus à accéder aux rapports d'εxodus, pourquoi ?](#eos)
 
 ---
 
@@ -81,6 +82,18 @@ Non, bien sûr, vous pouvez allez voir [son propre rapport d'analyse](https://re
 L'objectif d'Exodus Privacy est de toucher le plus grand nombre, les personnes les moins technophiles et les plus enclines à ignorer ce qui se passe dans leur ordiphone. Pour toucher ce public, il est nécessaire d'aller à lui, car il ne viendra pas à nous. Nous avons donc une chaîne YouTube et un page Facebook.
 
 Vous pouvez retrouver les liens de nos différents supports dans [la page suivante](/fr/page/what/#videos).
+
+---
+
+**J'ai un smartphone avec /e/OS et mon application App Lounge n'arrive plus à accéder aux rapports d'εxodus, pourquoi ?  <a class="anchor" name="eos"></a>**
+
+Il est possible que nous ayons bloqué votre client App Lounge.
+
+Depuis quelques années des serveurs de /e/OS faisaient des requêtes sur notre API avec une clé que nous leur avions fournit. Cependant en octobre 2024, les requêtes de /e/ devenant trop importantes pour nos serveurs (et notre demande de mettre un meilleur cache de leur côté ayant échouée), nous leur avons indiqué que cela ne serait plus possible et leur avons laissé plusieurs mois pour changer de solution (comme héberger une instance d'εxodus chez eux). En effet, malgré leur proposition de financement, nous n'avons pas les moyens humains ni la volonté d'être prestataire de service pour des entreprises.
+
+Malgré cela, c'est le magasin d'applications "App Lounge" de /e/OS qui s'est mis à faire des requêtes vers notre API, directement depuis les smartphones /e/OS, engendrant un DDoS de notre infrastructure.
+
+Le 6 mars 2025 nous avons donc pris la décision de bloquer les requêtes des clients "App Lounge" de /e/OS afin de soulager nos serveurs. Seuls les clients App Lounge sont bloqués, votre adresse n'est pas bannie et vous pouvez toujours consulter la plateforme εxodus.
 
 <style>
 a.anchor {


### PR DESCRIPTION
## Goal

- Add /e/OS `App Lounge` block information
- Add developer name and certificate presence information